### PR TITLE
Add in option to disable max requests killing if the user chooses

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Add these lines to your `config.ru`.
     
     # Max requests per worker
     use Unicorn::WorkerKiller::MaxRequests, 3072, 4096
+
+    *note: use Unicorn::WorkerKiller::MaxRequests, 0, 0 disables MaxRequests checking*
     
     # Max memory size (RSS) per worker
     use Unicorn::WorkerKiller::Oom, (192*(1024**2)), (256*(1024**2))

--- a/lib/unicorn/worker_killer.rb
+++ b/lib/unicorn/worker_killer.rb
@@ -66,12 +66,12 @@ module Unicorn::WorkerKiller
               value = ls[1].to_i
               unit = ls[2]
               case unit.downcase
-              when 'kb'
-                return value*(1024**1)
-              when 'mb'
-                return value*(1024**2)
-              when 'gb'
-                return value*(1024**3)
+                when 'kb'
+                  return value*(1024**1)
+                when 'mb'
+                  return value*(1024**2)
+                when 'gb'
+                  return value*(1024**3)
               end
             end
           end
@@ -108,7 +108,9 @@ module Unicorn::WorkerKiller
       @_worker_max_requests ||= @_worker_cur_requests
       super(client) # Unicorn::HttpServer#process_client
 
-      if (@_worker_cur_requests -= 1) <= 0
+      if @_worker_max_requests_min == 0 && @_worker_max_requests_max == 0 # bypass the max requests work if but min & max are set to zero
+        logger.warn "MaxRequests check disabled"
+      elsif (@_worker_cur_requests -= 1) <= 0
         logger.warn "#{self}: worker (pid: #{Process.pid}) exceeds max number of requests (limit: #{@_worker_max_requests})"
         Unicorn::WorkerKiller.kill_self(logger, @_worker_process_start)
       end


### PR DESCRIPTION
Added in an if call to lib/unicorn/worker_killer.rb to check if the `use Unicorn::WorkerKiller::MaxRequests, 0, 0` is set. If so it bypasses the MaxRequest check.

We found we needed this on a larger site (~40k concurrent sessions) as requests quickly built up and it was really the memory we were interested in anyway. Limited the number of unicorn deaths without removing the overall usefulness of the gem.
