### PR TITLE
Ruby 1.8 rand fixes

### DIFF
--- a/lib/unicorn/worker_killer.rb
+++ b/lib/unicorn/worker_killer.rb
@@ -38,13 +38,17 @@ module Unicorn::WorkerKiller
       end
       app # pretend to be Rack middleware since it was in the past
     end
-
+    
+    def randomize(integer)
+      RUBY_VERSION > "1.9" ? Random.rand(integer) : rand(integer)
+    end
+    
     def process_client(client)
       super(client) # Unicorn::HttpServer#process_client
       return if @_worker_memory_limit_min == 0 && @_worker_memory_limit_max == 0
 
       @_worker_process_start ||= Time.now
-      @_worker_memory_limit ||= @_worker_memory_limit_min + Random.rand(@_worker_memory_limit_max-@_worker_memory_limit_min+1)
+      @_worker_memory_limit ||= @_worker_memory_limit_min + randomize(@_worker_memory_limit_max - @_worker_memory_limit_min + 1)
       @_worker_check_count += 1
       if @_worker_check_count % @_worker_check_cycle == 0
         rss = _worker_rss()
@@ -108,7 +112,7 @@ module Unicorn::WorkerKiller
       return if @_worker_max_requests_min == 0 && @_worker_max_requests_max == 0
 
       @_worker_process_start ||= Time.now
-      @_worker_cur_requests ||= @_worker_max_requests_min + Random.rand(@_worker_max_requests_max-@_worker_max_requests_min+1)
+      @_worker_cur_requests ||= @_worker_max_requests_min + randomize(@_worker_max_requests_max - @_worker_max_requests_min + 1)
       @_worker_max_requests ||= @_worker_cur_requests
       if (@_worker_cur_requests -= 1) <= 0
         logger.warn "#{self}: worker (pid: #{Process.pid}) exceeds max number of requests (limit: #{@_worker_max_requests})"


### PR DESCRIPTION
Fixes the issue with making calls to rand for Ruby 1.8.  Basically the same end result as https://github.com/kzk/unicorn-worker-killer/pull/10 but this should merge in cleaner.

If you want to just go with the other pull request, no hard feelings.  I just figured I'd put out an easy drop in fix so that people like myself can get back to using the canonical gem on Ruby 1.8 projects.
