### PR TITLE
Refactor memory code into separate gem

### DIFF
--- a/unicorn-worker-killer.gemspec
+++ b/unicorn-worker-killer.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
-  gem.add_dependency "unicorn", "~> 4"
+  gem.add_dependency "unicorn",         "~> 4"
+  gem.add_dependency "get_process_mem", "~> 0"
   gem.add_development_dependency "rake", ">= 0.9.2"
 end


### PR DESCRIPTION
Love the idea here, I was able to generalize the memory grabbing code into a gem here: https://github.com/schneems/get_process_mem

It would be nice if we could use this code outside of Unicorn-worker-killer as well as reduce the amount of code that must be maintained directly in this library.
