### PR TITLE
Allow max_quit and max_term to be set to falsey value 

### DIFF
--- a/lib/unicorn/worker_killer.rb
+++ b/lib/unicorn/worker_killer.rb
@@ -19,8 +19,8 @@ module Unicorn::WorkerKiller
     @@kill_attempts += 1
 
     sig = :QUIT
-    sig = :TERM if @@kill_attempts > configuration.max_quit
-    sig = :KILL if @@kill_attempts > configuration.max_term
+    sig = :TERM if configuration.max_quit && @@kill_attempts > configuration.max_quit
+    sig = :KILL if configuration.max_term && @@kill_attempts > configuration.max_term
 
     logger.warn "#{self} send SIG#{sig} (pid: #{worker_pid}) alive: #{alive_sec} sec (trial #{@@kill_attempts})"
     Process.kill sig, worker_pid


### PR DESCRIPTION
I had a case where I never wanted TERM or KILL signals to be sent to workers. 

This change allows configuration.max_quit and configuration.max_term to be set to falsey values so that only TERM is ever sent.
