### PR TITLE
Workaround for 'cannot load such file -- unicorn/worker_killer' errors.

### DIFF
--- a/lib/unicorn_worker_killer.rb
+++ b/lib/unicorn_worker_killer.rb
@@ -1,0 +1,2 @@
+require 'unicorn/configuration'
+require 'unicorn/worker_killer'


### PR DESCRIPTION
This defines a simple index file at the gem's root directory that you can point your Gemfile by using:

`gem 'unicorn-worker-killer', require: 'unicorn_worker_killer'`

This seems to satisfy config.ru when it can't load the file from its original location, as seen in https://github.com/kzk/unicorn-worker-killer/issues/35.

The require in config.ru needs to be updated to

`require 'unicorn_worker_killer'`
