### PR TITLE
Introduce #before_kill callback

### DIFF
--- a/lib/unicorn/worker_killer.rb
+++ b/lib/unicorn/worker_killer.rb
@@ -23,6 +23,8 @@ module Unicorn::WorkerKiller
     sig = :TERM if @@kill_attempts > configuration.max_quit
     sig = :KILL if @@kill_attempts > configuration.max_term
 
+    configuration.callback.call(sig)
+
     logger.warn "#{self} send SIG#{sig} (pid: #{worker_pid}) alive: #{alive_sec} sec (trial #{@@kill_attempts})"
     Process.kill sig, worker_pid
   end

--- a/lib/unicorn/worker_killer/configuration.rb
+++ b/lib/unicorn/worker_killer/configuration.rb
@@ -1,11 +1,16 @@
 module Unicorn::WorkerKiller
   class Configuration
-    attr_accessor :max_quit, :max_term, :sleep_interval
+    attr_accessor :max_quit, :max_term, :sleep_interval, :callback
 
     def initialize
       self.max_quit = 10
       self.max_term = 15
       self.sleep_interval = 1
+      self.callback = -> {}
+    end
+
+    def before_kill(&block)
+      self.callback = block
     end
   end
 end


### PR DESCRIPTION
I'm looking to introduce a callback before worker processes are killed. Although this library logs when signals are sent, it would still be useful to have an opportunity to capture some extra info before it's gone.

Here's an example of the new API:

``` ruby
require "unicorn/worker_killer"

Unicorn::WorkerKiller.configure do |config|
  config.before_kill do |signal|
    # do work here (e.g. capture extra info about process)
  end
end
```

Open for feedback. This feature proved to be useful for us.
