### PR TITLE
Remove Rdoc Flag

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,29 @@
+PATH
+  remote: .
+  specs:
+    unicorn-worker-killer (0.4.4)
+      get_process_mem (~> 0)
+      unicorn (>= 4, <= 6)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ffi (1.15.3)
+    get_process_mem (0.2.7)
+      ffi (~> 1.0)
+    kgio (2.11.4)
+    raindrops (0.19.2)
+    rake (13.0.6)
+    unicorn (6.0.0)
+      kgio (~> 2.6)
+      raindrops (~> 0.7)
+
+PLATFORMS
+  arm64-darwin-20
+
+DEPENDENCIES
+  rake (>= 0.9.2)
+  unicorn-worker-killer!
+
+BUNDLED WITH
+   2.2.25

--- a/unicorn-worker-killer.gemspec
+++ b/unicorn-worker-killer.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |gem|
   gem.version     = File.read("VERSION").strip
   gem.authors     = ["Kazuki Ohta", "Sadayuki Furuhashi", "Jonathan Clem"]
   gem.email       = ["kazuki.ohta@gmail.com", "frsyuki@gmail.com", "jonathan@jclem.net"]
-  gem.has_rdoc    = false
   #gem.platform    = Gem::Platform::RUBY
   gem.files       = `git ls-files`.split("\n")
   gem.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/unicorn-worker-killer.gemspec
+++ b/unicorn-worker-killer.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.licenses    = ["GPLv2+", "Ruby 1.8"]
   gem.require_paths = ['lib']
-  gem.add_dependency "unicorn",         [">= 4", "< 6"]
+  gem.add_dependency "unicorn",         [">= 4", "<= 6"]
   gem.add_dependency "get_process_mem", "~> 0"
   gem.add_development_dependency "rake", ">= 0.9.2"
 end


### PR DESCRIPTION
`has_rdoc` has been deprecated without replacement from Gemspecs.

Bumping Hub's Ruby version means the gem is installed from scratch and fails:

```
Tasks: TOP => deploy:updated => bundler:install
(See full trace by running task with --trace)
The deploy has failed with an error: Exception while executing as app@prod-orchid-cattle.itisonboxes.com: bundle exit status: 137
bundle stdout: Nothing written
bundle stderr: NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /u/apps/hub/shared/bundle/ruby/2.6.0/bundler/gems/unicorn-worker-killer-d7db53151039/unicorn-worker-killer.gemspec:12.
bash: line 1: 18010 Killed                  /opt/rbenv/bin/rbenv exec bundle install --path /u/apps/hub/shared/bundle --without development test --deployment --quiet


** DEPLOY FAILED
```