### PR TITLE
Compatible with unicorn versions after 6.1.0

### DIFF
--- a/lib/unicorn/worker_killer.rb
+++ b/lib/unicorn/worker_killer.rb
@@ -49,8 +49,8 @@ module Unicorn::WorkerKiller
       RUBY_VERSION > "1.9" ? Random.rand(integer.abs) : rand(integer)
     end
 
-    def process_client(client)
-      super(client) # Unicorn::HttpServer#process_client
+    def process_client(*client)
+      super(*client) # Unicorn::HttpServer#process_client
       return if @_worker_memory_limit_min == 0 && @_worker_memory_limit_max == 0
 
       @_worker_process_start ||= Time.now
@@ -89,8 +89,8 @@ module Unicorn::WorkerKiller
       RUBY_VERSION > "1.9" ? Random.rand(integer.abs) : rand(integer)
     end
 
-    def process_client(client)
-      super(client) # Unicorn::HttpServer#process_client
+    def process_client(*client)
+      super(*client) # Unicorn::HttpServer#process_client
       return if @_worker_max_requests_min == 0 && @_worker_max_requests_max == 0
 
       @_worker_process_start ||= Time.now


### PR DESCRIPTION
This PR adapts the call to unicorn by splatting the arguments and passing them on.

The change in arity happened in  this commit: https://github.com/k0kubun/unicorn/commit/b652fa51c1342496bdcdecca8e567f1fb46c41c9 

This PR is compatible with 6.1.0 and with (as yet unreleased) later versions.

I tried with the fork at https://github.com/k0kubun/unicorn/tree/ruby-3-4 - and then I started this.

To try it:

```ruby
gem "unicorn", github: "k0kubun/unicorn", branch: "ruby-3-4" # See https://github.com/k0kubun/unicorn/tree/ruby-3-4
gem "unicorn-worker-killer", github: "olleolleolle/unicorn-worker-killer", branch: "compatible-with-next"
```

See #79 